### PR TITLE
feat: add output port for the wind pose

### DIFF
--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -21,6 +21,9 @@ task_context 'WindSourceTask', subclasses: 'rock_gazebo::ModelPluginTask' do
 
     # Wind velocity input port
     input_port 'wind_velocity', '/base/Vector3d'
+
+    # Wind pose output port
+    output_port 'wind_pose', '/base/samples/RigidBodyState'
 end
 
 task_context 'WaveSourceTask', subclasses: 'rock_gazebo::ModelPluginTask' do
@@ -49,18 +52,18 @@ task_context 'TetherSimulationTask' do
     property 'max_tether_length', '/double'
 
     property 'tether_config', '/uuv_tether_control/TetherDragAndInertiaConfig'
-    
+
     # The rov's link where the tether is attached
     input_port 'rov_attachment', '/base/samples/RigidBodyState'
 
     # The usv's link where the tether is attached   
     input_port 'usv_attachment', '/base/samples/RigidBodyState'
-   
+
     # Water speed over ground, expressed in the rov 
     input_port 'water_speed', '/base/Vector3d'
 
     output_port 'rov_force', 'base/Vector3d'
-   
+
     output_port 'usv_force', '/base/Vector3d'
 
     port_driven

--- a/tasks/WindSourceTask.cpp
+++ b/tasks/WindSourceTask.cpp
@@ -48,6 +48,11 @@ void WindSourceTask::updateHook()
     base::Vector3d wind_velocity;
     if (_wind_velocity.read(wind_velocity) != RTT::NewData)
         return;
+
+    base::samples::RigidBodyState wind_pose;
+    wind_pose.velocity = wind_velocity;
+    _wind_pose.write(wind_pose);
+
     gazebo::msgs::Vector3d wind_vel_msg;
     wind_vel_msg.set_x(wind_velocity.x());
     wind_vel_msg.set_y(wind_velocity.y());

--- a/tasks/WindSourceTask.cpp
+++ b/tasks/WindSourceTask.cpp
@@ -66,6 +66,10 @@ void WindSourceTask::errorHook()
 }
 void WindSourceTask::stopHook()
 {
+    base::samples::RigidBodyState wind_pose;
+    wind_pose.velocity = Eigen::Vector3d::Zero();
+    _wind_pose.write(wind_pose);
+
     gazebo::msgs::Vector3d wind_vel_msg;
     wind_vel_msg.set_x(0);
     wind_vel_msg.set_y(0);


### PR DESCRIPTION
# What is this PR for
Adds a wind pose output port for the WindSourceTask

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
