### PR TITLE
feat: Create the ThrusterLimitationTask

### DIFF
--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -76,12 +76,8 @@ task_context "ThrusterLimitationTask" do
     needs_configuration
 
     # Control limits
-    #
-    # You may only set the speed and effort fields. Setting any other field
-    # will fail on configure
-    #
-    # If set, min and max speeds need to be the opposite of each other. The
-    # controller does not support limiting them separately
+    # To replicate the same behaviour of the live system, set the min and max speeds to be
+    # the opposite of each other.
     property "limits", "/base/JointLimits"
 
     # The input thruster command

--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -6,6 +6,7 @@ import_types_from "gazebo_usvTypes.hpp"
 
 import_types_from "std"
 import_types_from "base"
+import_types_from "control_base"
 
 using_library "gazebo"
 using_library "base-logging"
@@ -67,4 +68,26 @@ task_context 'TetherSimulationTask' do
     output_port 'usv_force', '/base/Vector3d'
 
     port_driven
+end
+
+task_context "ThrusterLimitationTask" do
+    needs_configuration
+
+    # Control limits
+    #
+    # You may only set the speed and effort fields. Setting any other field
+    # will fail on configure
+    #
+    # If set, min and max speeds need to be the opposite of each other. The
+    # controller does not support limiting them separately
+    property "limits", "/base/JointLimits"
+
+    # The input thruster command
+    input_port "cmd_in", "/base/commands/Joints"
+    # The output thruster command
+    output_port "cmd_out", "/base/commands/Joints"
+    # The thruster saturation signal
+    output_port "saturation_signal", "/control_base/SaturationSignal"
+
+    periodic 0.1
 end

--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -70,6 +70,8 @@ task_context 'TetherSimulationTask' do
     port_driven
 end
 
+# Task to limit the propulsion command and output the saturation signal when
+# the inputed command is out of the range
 task_context "ThrusterLimitationTask" do
     needs_configuration
 
@@ -88,6 +90,8 @@ task_context "ThrusterLimitationTask" do
     output_port "cmd_out", "/base/commands/Joints"
     # The thruster saturation signal
     output_port "saturation_signal", "/control_base/SaturationSignal"
+
+    exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"
 
     periodic 0.1
 end

--- a/manifest.xml
+++ b/manifest.xml
@@ -9,5 +9,6 @@
   <depend package="base/cmake" />
   <depend package="simulation/orogen/rock_gazebo"/>
   <depend package="control/uuv_tether_control"/>
+  <depend package="control/orogen/control_base"/>
   <test_depend name="tools/syskit" />
 </package>

--- a/tasks/ThrusterLimitationTask.cpp
+++ b/tasks/ThrusterLimitationTask.cpp
@@ -1,0 +1,89 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ThrusterLimitationTask.hpp"
+#include <algorithm>
+
+using namespace std;
+using namespace base;
+using namespace gazebo_usv;
+using namespace control_base;
+
+ThrusterLimitationTask::ThrusterLimitationTask(std::string const& name)
+    : ThrusterLimitationTaskBase(name)
+{
+}
+
+ThrusterLimitationTask::~ThrusterLimitationTask()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ThrusterLimitationTask.hpp for more detailed
+// documentation about them.
+
+bool ThrusterLimitationTask::configureHook()
+{
+    if (!ThrusterLimitationTaskBase::configureHook()) {
+        return false;
+    }
+    m_limits = _limits.get();
+    if (m_limits.elements.empty()) {
+        // Initialize speed limits as infinity
+        JointLimits infinity;
+        JointLimitRange range;
+        range.Speed(-base::infinity<float>(), base::infinity<float>());
+        infinity.elements.push_back(range);
+        m_limits = infinity;
+    }
+
+    return true;
+}
+
+bool ThrusterLimitationTask::startHook()
+{
+    if (!ThrusterLimitationTaskBase::startHook()) {
+        return false;
+    }
+    return true;
+}
+
+bool ThrusterLimitationTask::checkSpeedSaturation(commands::Joints const& cmd)
+{
+    return cmd.elements[0].speed >= m_limits.elements[0].max.speed ||
+           cmd.elements[0].speed <= m_limits.elements[0].min.speed;
+}
+
+void ThrusterLimitationTask::updateHook()
+{
+    commands::Joints cmd_in;
+    if (_cmd_in.read(cmd_in) != RTT::NewData) {
+        return;
+    }
+
+    SaturationSignal saturation_signal;
+    saturation_signal.value = checkSpeedSaturation(cmd_in);
+    saturation_signal.time = cmd_in.time;
+    _saturation_signal.write(saturation_signal);
+
+    commands::Joints cmd_out;
+    cmd_out.elements[0].speed = clamp(cmd_in.elements[0].speed,
+        m_limits.elements[0].min.speed,
+        m_limits.elements[0].max.speed);
+    cmd_out.time = Time::now();
+    _cmd_out.write(cmd_out);
+
+    ThrusterLimitationTaskBase::updateHook();
+}
+
+void ThrusterLimitationTask::errorHook()
+{
+    ThrusterLimitationTaskBase::errorHook();
+}
+void ThrusterLimitationTask::stopHook()
+{
+    ThrusterLimitationTaskBase::stopHook();
+}
+void ThrusterLimitationTask::cleanupHook()
+{
+    ThrusterLimitationTaskBase::cleanupHook();
+}

--- a/tasks/ThrusterLimitationTask.cpp
+++ b/tasks/ThrusterLimitationTask.cpp
@@ -53,7 +53,7 @@ bool ThrusterLimitationTask::checkSpeedSaturation(commands::Joints const& cmd)
            cmd.elements[0].speed <= m_limits.elements[0].min.speed;
 }
 
-void ThrusterLimitationTask::evaluateSpeedCommand(commands::Joints const& cmd)
+void ThrusterLimitationTask::validateSpeedCommand(commands::Joints const& cmd)
 {
     if (cmd.elements.size() != 1) {
         return exception(INVALID_COMMAND_SIZE);
@@ -73,7 +73,7 @@ void ThrusterLimitationTask::updateHook()
     if (_cmd_in.read(cmd_in) != RTT::NewData) {
         return;
     }
-    evaluateSpeedCommand(cmd_in);
+    validateSpeedCommand(cmd_in);
 
     SaturationSignal saturation_signal;
     saturation_signal.value = checkSpeedSaturation(cmd_in);

--- a/tasks/ThrusterLimitationTask.hpp
+++ b/tasks/ThrusterLimitationTask.hpp
@@ -1,0 +1,107 @@
+#ifndef GAZEBO_USV_ThrusterLimitationTask_TASK_HPP
+#define GAZEBO_USV_ThrusterLimitationTask_TASK_HPP
+
+#include "base/commands/Joints.hpp"
+#include "gazebo_usv/ThrusterLimitationTaskBase.hpp"
+
+namespace gazebo_usv {
+
+    /*! \class ThrusterLimitationTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','gazebo_usv::ThrusterLimitationTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class ThrusterLimitationTask : public ThrusterLimitationTaskBase {
+        friend class ThrusterLimitationTaskBase;
+
+    private:
+        base::JointLimits m_limits;
+        bool checkSpeedSaturation(base::commands::Joints const& cmd);
+
+    public:
+        /** TaskContext constructor for ThrusterLimitationTask
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        ThrusterLimitationTask(
+            std::string const& name = "gazebo_usv::ThrusterLimitationTask");
+
+        /** Default deconstructor of ThrusterLimitationTask
+         */
+        ~ThrusterLimitationTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/tasks/ThrusterLimitationTask.hpp
+++ b/tasks/ThrusterLimitationTask.hpp
@@ -30,6 +30,7 @@ namespace gazebo_usv {
     private:
         base::JointLimits m_limits;
         bool checkSpeedSaturation(base::commands::Joints const& cmd);
+        void evaluateSpeedCommand(base::commands::Joints const& cmd);
 
     public:
         /** TaskContext constructor for ThrusterLimitationTask

--- a/tasks/ThrusterLimitationTask.hpp
+++ b/tasks/ThrusterLimitationTask.hpp
@@ -30,7 +30,7 @@ namespace gazebo_usv {
     private:
         base::JointLimits m_limits;
         bool checkSpeedSaturation(base::commands::Joints const& cmd);
-        void evaluateSpeedCommand(base::commands::Joints const& cmd);
+        void validateSpeedCommand(base::commands::Joints const& cmd);
 
     public:
         /** TaskContext constructor for ThrusterLimitationTask

--- a/test/thruster_limitation_task_test.rb
+++ b/test/thruster_limitation_task_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+using_task_library "gazebo_usv"
+import_types_from "base"
+import_types_from "gazebo_usv"
+
+describe OroGen.gazebo_usv.ThrusterLimitationTask do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen
+            .gazebo_usv
+            .ThrusterLimitationTask
+            .deployed_as("thruster_limitation_test")
+        )
+
+        @task.properties.limits = Types.base.JointLimits.new(
+            elements: [{
+                min: Types.base.JointState.Speed(-1000),
+                max: Types.base.JointState.Speed(1000)
+            }]
+        )
+
+        @max_cmd = Types.base.samples.Joints.new(elements: [{ speed: 1000 }])
+        @min_cmd = Types.base.samples.Joints.new(elements: [{ speed: -1000 }])
+
+        @cmd = Types.base.samples.Joints.new(elements: [{ speed: 500 }])
+        @cmd_above_the_max_limit = Types.base.samples.Joints.new(
+            elements: [{ speed: 1100 }]
+        )
+        @cmd_below_the_min_limit = Types.base.samples.Joints.new(
+            elements: [{ speed: -1100 }]
+        )
+
+        @saturated_signal = Types.control_base.SaturationSignal.new(value: true)
+        @not_saturated_signal = Types.control_base.SaturationSignal.new(value: false)
+    end
+
+    it "does not return any saturation signal when there is no input command" do
+        syskit_configure_and_start(@task)
+        expect_execution.to do
+            have_no_new_sample(task.saturation_signal_port, at_least_during: 0.2)
+        end
+    end
+
+    it "does not return any output command when there is no input command" do
+        syskit_configure_and_start(@task)
+        expect_execution.to do
+            have_no_new_sample(task.cmd_out_port, at_least_during: 0.2)
+        end
+    end
+
+    it "forwards the input command when it is inside the limited range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd
+        end.to do
+            have_one_new_sample(task.cmd_out_port)
+        end
+
+        assert_equal(@cmd.elements[0].speed, output.elements[0].speed)
+    end
+
+    it "limits the input command when it is bigger than the max limit range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd_above_the_max_limit
+        end.to do
+            have_one_new_sample(task.cmd_out_port)
+        end
+
+        assert_equal(@max_cmd.elements[0].speed, output.elements[0].speed)
+    end
+
+    it "limits the input command when it is smaller than the min limit range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd_below_the_min_limit
+        end.to do
+            have_one_new_sample(task.cmd_out_port)
+        end
+
+        assert_equal(@min_cmd.elements[0].speed, output.elements[0].speed)
+    end
+
+    it "returns a saturated signal when the input command is out of the limited range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd_above_the_max_limit
+        end.to do
+            have_one_new_sample(task.saturation_signal_port)
+        end
+        assert_equal(@saturated_signal, output)
+
+        output_2 = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd_below_the_min_limit
+        end.to do
+            have_one_new_sample(task.saturation_signal_port)
+        end
+        assert_equal(@saturated_signal, output_2)
+    end
+
+    it "returns a no saturated signal when the input command within the limited range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.cmd_in_port, @cmd
+        end.to do
+            have_one_new_sample(task.saturation_signal_port)
+        end
+
+        assert_equal(@not_saturated_signal, output)
+    end
+end


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
Create a component to simulate the propulsion saturation signals and limit the thruster commands.
[sc-62701]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
