### PR TITLE
fix: Refactor the ThrusterLimitationTask to limit the effort instead of speed

### DIFF
--- a/tasks/ThrusterLimitationTask.hpp
+++ b/tasks/ThrusterLimitationTask.hpp
@@ -29,8 +29,9 @@ namespace gazebo_usv {
 
     private:
         base::JointLimits m_limits;
-        bool checkSpeedSaturation(base::commands::Joints const& cmd);
-        void validateSpeedCommand(base::commands::Joints const& cmd);
+        bool checkEffortSaturation(base::commands::Joints const& cmd);
+        void validateEffortCommand(base::commands::Joints const& cmd);
+        base::commands::Joints saturateCommand(base::commands::Joints const& cmd);
 
     public:
         /** TaskContext constructor for ThrusterLimitationTask


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
I still need fix the unit tests.
I tested on gazebo simulation

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
