### PR TITLE
feat: Create a component to simulate the reed switch behavior

### DIFF
--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -7,6 +7,7 @@ import_types_from "gazebo_usvTypes.hpp"
 import_types_from "std"
 import_types_from "base"
 import_types_from "control_base"
+import_types_from "linux_gpios"
 
 using_library "gazebo"
 using_library "base-logging"
@@ -90,4 +91,25 @@ task_context "ThrusterLimitationTask" do
     exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"
 
     periodic 0.1
+end
+
+# Component to simulate the reed switch sensor behaviour
+# For each revolution cycle there is a range where the reed switch is triggered
+task_context "ReedSwitchSimulatorTask" do
+    needs_configuration
+
+    # The time for one cycle
+    property "revolution_time", "/base/Time"
+    # The reed swicth sensor is ON for the first trigger_time in each cycle
+    property "trigger_time", "/base/Time"
+
+    # The gpio state used to retract the system
+    input_port "gpio_retract", "/linux_gpios/GPIOState"
+    # The gpio state used to extend the system
+    input_port "gpio_extend", "/linux_gpios/GPIOState"
+    # The reed switch gpio state used to count revolutions
+    output_port "gpio_reed_switch", "/linux_gpios/GPIOState"
+
+    exception_states "INVALID_GPIO_SIZE"
+    periodic 0.01
 end

--- a/manifest.xml
+++ b/manifest.xml
@@ -10,5 +10,6 @@
   <depend package="simulation/orogen/rock_gazebo"/>
   <depend package="control/uuv_tether_control"/>
   <depend package="control/orogen/control_base"/>
+  <depend package="drivers/orogen/linux_gpios"/>
   <test_depend name="tools/syskit" />
 </package>

--- a/tasks/ReedSwitchSimulatorTask.cpp
+++ b/tasks/ReedSwitchSimulatorTask.cpp
@@ -1,0 +1,149 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ReedSwitchSimulatorTask.hpp"
+#include <base-logging/Logging.hpp>
+
+using namespace std;
+using namespace base;
+using namespace gazebo_usv;
+using namespace linux_gpios;
+
+ReedSwitchSimulatorTask::ReedSwitchSimulatorTask(std::string const& name)
+    : ReedSwitchSimulatorTaskBase(name)
+{
+}
+
+ReedSwitchSimulatorTask::~ReedSwitchSimulatorTask()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ReedSwitchSimulatorTask.hpp for more detailed
+// documentation about them.
+
+bool ReedSwitchSimulatorTask::validateGpio(linux_gpios::GPIOState const& gpio)
+{
+    if (gpio.states.size() != 1) {
+        LOG_FATAL_S << "received a gpio state of size " << gpio.states.size();
+        exception(INVALID_GPIO_SIZE);
+        return false;
+    }
+    return true;
+}
+
+bool ReedSwitchSimulatorTask::configureHook()
+{
+    if (!ReedSwitchSimulatorTaskBase::configureHook()) {
+        return false;
+    }
+    m_revolution_time = _revolution_time.get();
+    m_trigger_time = _trigger_time.get();
+    return true;
+}
+
+bool ReedSwitchSimulatorTask::startHook()
+{
+    if (!ReedSwitchSimulatorTaskBase::startHook()) {
+        return false;
+    }
+    m_timer = 0;
+    return true;
+}
+
+void ReedSwitchSimulatorTask::updateTimeInCycle(int64_t delta)
+{
+    int64_t updated_timer = m_timer + delta;
+    if (updated_timer < 0) {
+        int16_t number_of_revolutions =
+            static_cast<int16_t>(abs(delta / m_revolution_time.microseconds)) + 1;
+        updated_timer += number_of_revolutions * m_revolution_time.microseconds;
+    }
+    // Normalize the updated_timer in a time inside one revolution.
+    m_timer = updated_timer % m_revolution_time.microseconds;
+}
+
+CommandDirection motorCommand(GPIOState const& extend,
+    GPIOState const& retract,
+    Time const& now)
+{
+    bool extend_state = extend.states[0].data;
+    bool retract_state = retract.states[0].data;
+    if (!extend_state && !retract_state) {
+        return CommandDirection{0, now};
+    }
+    else if (extend_state && !retract_state) {
+        return CommandDirection{1, now};
+    }
+    else if (!extend_state && retract_state) {
+        return CommandDirection{-1, now};
+    }
+    else {
+        throw std::runtime_error("Invalid command direction - Both gpio states should "
+                                 "not be true at the same time.");
+    }
+}
+
+void ReedSwitchSimulatorTask::updateMotorCommandDirection(GPIOState const& extend,
+    GPIOState const& retract,
+    Time const& now)
+{
+    CommandDirection command_direction = motorCommand(extend, retract, now);
+    if (m_last_command_direction.has_value()) {
+        Time delta_time = now - m_last_command_direction->time;
+        updateTimeInCycle(delta_time.microseconds * m_last_command_direction->direction);
+    }
+    m_last_command_direction = command_direction;
+}
+
+GPIOState gpio(bool flag, Time const& now)
+{
+    GPIOState gpio;
+    gpio.time = now;
+    gpio.states.resize(1);
+    gpio.states[0].time = now;
+    gpio.states[0].data = flag;
+    return gpio;
+}
+
+bool ReedSwitchSimulatorTask::sensorActive()
+{
+    return m_timer <= m_trigger_time.microseconds;
+}
+
+void ReedSwitchSimulatorTask::updateHook()
+{
+    ReedSwitchSimulatorTaskBase::updateHook();
+
+    GPIOState gpio_retract;
+    if (_gpio_retract.read(gpio_retract) == RTT::NoData) {
+        return;
+    }
+    GPIOState gpio_extend;
+    if (_gpio_extend.read(gpio_extend) == RTT::NoData) {
+        return;
+    }
+    if (!validateGpio(gpio_retract) || !validateGpio(gpio_extend)) {
+        return;
+    }
+
+    Time now = Time::now();
+    updateMotorCommandDirection(gpio_extend, gpio_retract, now);
+
+    GPIOState gpio_reed_switch = gpio(sensorActive(), now);
+    _gpio_reed_switch.write(gpio_reed_switch);
+}
+
+void ReedSwitchSimulatorTask::errorHook()
+{
+    ReedSwitchSimulatorTaskBase::errorHook();
+}
+void ReedSwitchSimulatorTask::stopHook()
+{
+    ReedSwitchSimulatorTaskBase::stopHook();
+    m_last_command_direction = {};
+    m_timer = 0;
+}
+void ReedSwitchSimulatorTask::cleanupHook()
+{
+    ReedSwitchSimulatorTaskBase::cleanupHook();
+}

--- a/tasks/ReedSwitchSimulatorTask.hpp
+++ b/tasks/ReedSwitchSimulatorTask.hpp
@@ -1,0 +1,134 @@
+#ifndef GAZEBO_USV_ReedSwitchSimulatorTask_TASK_HPP
+#define GAZEBO_USV_ReedSwitchSimulatorTask_TASK_HPP
+
+#include "base/Time.hpp"
+#include "base/commands/Joints.hpp"
+#include "gazebo_usv/ReedSwitchSimulatorTaskBase.hpp"
+#include <optional>
+
+namespace gazebo_usv {
+
+    /*! \class ReedSwitchSimulatorTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','gazebo_usv::ReedSwitchSimulatorTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    struct CommandDirection {
+        int direction = 0;
+        base::Time time;
+    };
+
+    class ReedSwitchSimulatorTask : public ReedSwitchSimulatorTaskBase {
+        friend class ReedSwitchSimulatorTaskBase;
+
+    private:
+        std::optional<CommandDirection> m_last_command_direction;
+        /**
+         * The timer is like a pointer of the clock.
+         * This indicates the region where the sensor is reading.
+         */
+        int64_t m_timer = 0;
+        /**
+         * The revolution time is the total time of one clock cycle
+         */
+        base::Time m_revolution_time;
+        /**
+         * The trigger time is the clock region where the sensor is at trigger level.
+         * It starts from zero to trigger_time. All other regions in the clock is non
+         * trigger level.
+         */
+        base::Time m_trigger_time;
+
+        void updateTimeInCycle(int64_t delta);
+        void updateMotorCommandDirection(linux_gpios::GPIOState const& extend,
+            linux_gpios::GPIOState const& retract, base::Time const& now);
+        bool sensorActive();
+        bool validateGpio(linux_gpios::GPIOState const& gpio);
+
+    public:
+        /** TaskContext constructor for ReedSwitchSimulatorTask
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        ReedSwitchSimulatorTask(
+            std::string const& name = "gazebo_usv::ReedSwitchSimulatorTask");
+
+        /** Default deconstructor of ReedSwitchSimulatorTask
+         */
+        ~ReedSwitchSimulatorTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/test/reed_switch_simulator_task_test.rb
+++ b/test/reed_switch_simulator_task_test.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+using_task_library "gazebo_usv"
+import_types_from "base"
+import_types_from "gazebo_usv"
+
+describe OroGen.gazebo_usv.ReedSwitchSimulatorTask do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen.gazebo_usv.ReedSwitchSimulatorTask.deployed_as("reed_simulator_test")
+        )
+        @task.properties.revolution_time = Time.at(1)
+        @task.properties.trigger_time = Time.at(0.3)
+
+        @gpio_true = gpio_state(1)
+        @gpio_false = gpio_state(0)
+    end
+
+    def gpio_state(state)
+        Types.linux_gpios.GPIOState.new(
+            time: Time.now, states: [{ time: Time.now, data: state }]
+        )
+    end
+
+    def assert_gpio_state(expected_state, gpio)
+        assert_equal(expected_state, gpio.states[0].data)
+    end
+
+    it "does not return any sample when there is no gpio_retract" do
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(1)
+        end.to do
+            have_no_new_sample(task.gpio_reed_switch_port, at_least_during: 0.2)
+        end
+    end
+
+    it "emits an invalid gpio size exception when the gpio size is bigger than "\
+    "expected" do
+        wrong_gpio = Types.linux_gpios.GPIOState.new(
+            time: Time.now, states: [{ time: Time.now, data: 1 },
+                                     { time: Time.now, data: 1 }]
+        )
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_extend_port, wrong_gpio
+            syskit_write @task.gpio_retract_port, gpio_state(1)
+        end.to_emit @task.invalid_gpio_size_event
+    end
+
+     it "emits an invalid gpio size exception when the gpio size is smaller than "\
+    "expected" do
+        wrong_gpio = Types.linux_gpios.GPIOState.new(
+            time: Time.now, states: []
+        )
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_retract_port, wrong_gpio
+            syskit_write @task.gpio_extend_port, gpio_state(1)
+        end.to_emit @task.invalid_gpio_size_event
+    end
+
+    it "does not return any sample when there is no gpio_extend" do
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_retract_port, gpio_state(1)
+        end.to do
+            have_no_new_sample(task.gpio_reed_switch_port, at_least_during: 0.2)
+        end
+    end
+
+    it "throw an error when both gpio states are true" do
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(1)
+            syskit_write @task.gpio_retract_port, gpio_state(1)
+        end.to do
+            emit task.exception_event
+        end
+    end
+
+    it "reports reed switch ON at start" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(0)
+            syskit_write @task.gpio_retract_port, gpio_state(0)
+        end.to do
+            have_one_new_sample(task.gpio_reed_switch_port)
+        end
+        assert_gpio_state(1, output)
+    end
+
+    it "keeps reporting the reed switch state at trigger level when there is no command "\
+    "to move and timer is on the trigger range" do
+        syskit_configure_and_start(@task)
+        output = expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(0)
+            syskit_write @task.gpio_retract_port, gpio_state(0)
+        end.to do
+            have_one_new_sample(task.gpio_reed_switch_port)
+        end
+        assert_gpio_state(1, output)
+
+        expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(0)
+            syskit_write @task.gpio_retract_port, gpio_state(0)
+        end.to do
+            have_no_new_sample(task.gpio_reed_switch_port, at_least_during: 1.2)
+                .matching { |s| s.states[0].data == 0 }
+        end
+    end
+
+    it "reports the reed switch state as true just during the trigger range for the CW "\
+    "direction" do
+        syskit_configure_and_start(@task)
+        2.times do
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(1)
+                syskit_write @task.gpio_retract_port, gpio_state(0)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 1 }
+            end
+            tic = Time.now
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(1)
+                syskit_write @task.gpio_retract_port, gpio_state(0)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 0 }
+            end
+            toc = Time.now
+            trigger_range_computed = toc - tic
+            assert(trigger_range_computed <= 0.4)
+        end
+    end
+
+    it "reports the reed switch state as false when outside the trigger range for the "\
+    "CW direction" do
+        syskit_configure_and_start(@task)
+        2.times do
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(1)
+                syskit_write @task.gpio_retract_port, gpio_state(0)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 0 }
+            end
+            tic = Time.now
+            expect_execution.timeout(3.0) do
+                syskit_write @task.gpio_extend_port, gpio_state(1)
+                syskit_write @task.gpio_retract_port, gpio_state(0)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 1 }
+            end
+            toc = Time.now
+            non_trigger_range_computed = toc - tic
+            assert(non_trigger_range_computed <= 0.8)
+        end
+    end
+
+    it "reports the reed switch state as true just during the trigger range for the CCW "\
+    "direction" do
+        syskit_configure_and_start(@task)
+        expect_execution do
+            syskit_write @task.gpio_extend_port, gpio_state(0)
+            syskit_write @task.gpio_retract_port, gpio_state(1)
+        end.to do
+            have_one_new_sample(task.gpio_reed_switch_port)
+                .matching { |s| s.states[0].data == 0 }
+        end
+        2.times do
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(0)
+                syskit_write @task.gpio_retract_port, gpio_state(1)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 1 }
+            end
+            tic = Time.now
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(0)
+                syskit_write @task.gpio_retract_port, gpio_state(1)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 0 }
+            end
+            toc = Time.now
+            trigger_range_computed = toc - tic
+            assert(trigger_range_computed <= 0.4)
+        end
+    end
+
+    it "reports the reed switch state as false when outside the trigger range for the "\
+    "CCW direction" do
+        syskit_configure_and_start(@task)
+        2.times do
+            expect_execution do
+                syskit_write @task.gpio_extend_port, gpio_state(0)
+                syskit_write @task.gpio_retract_port, gpio_state(1)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 0 }
+            end
+            tic = Time.now
+            expect_execution.timeout(3.0) do
+                syskit_write @task.gpio_extend_port, gpio_state(0)
+                syskit_write @task.gpio_retract_port, gpio_state(1)
+            end.to do
+                have_one_new_sample(task.gpio_reed_switch_port)
+                    .matching { |s| s.states[0].data == 1 }
+            end
+            toc = Time.now
+            non_trigger_range_computed = toc - tic
+            assert(non_trigger_range_computed <= 0.8)
+        end
+    end
+end


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
Component to simulate the reed switch behavior.
[sc-74582]

# How I did it
Imagine a clock where the total time is defined by the revolution_time property, and there is section in this clock that triggers the reed switch sensor. This trigger section is defined by the trigger_time property.
Every time that the 'clock hand' (m_timer) is located on trigger area the gpio_reed_switch will the at the trigger level, when its outside this section it will be at non trigger level.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
