### PR TITLE
feat: add task to convert rudder linear position into analog feedback

### DIFF
--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -8,6 +8,7 @@ import_types_from "std"
 import_types_from "base"
 import_types_from "control_base"
 import_types_from "linux_gpios"
+import_types_from "raw_io"
 
 using_library "gazebo"
 using_library "base-logging"
@@ -112,4 +113,27 @@ task_context "ReedSwitchSimulatorTask" do
 
     exception_states "INVALID_GPIO_SIZE"
     periodic 0.01
+end
+
+# Task that computes the analog feedback based on the rudder's linear position
+task_context "RudderActuatorPositionToAnalogTask" do
+    needs_configuration
+
+    # The analog input when the position is the minimun
+    property "input_min", "/float", -1
+    # The analog input when the position is the maximum
+    property "input_max", "/float", 1
+    # The minimum position
+    property "position_min", "/float", -1
+    # The maximum position
+    property "position_max", "/float", 1
+
+    # The analog readings
+    output_port "analog_input", "/std/vector</raw_io/Analog>"
+    # The position samples
+    input_port "position_samples", "/base/samples/Joints"
+
+    exception_states "INVALID_POSITION_SAMPLE"
+
+    port_driven
 end

--- a/gazebo_usv.orogen
+++ b/gazebo_usv.orogen
@@ -120,16 +120,16 @@ task_context "RudderActuatorPositionToAnalogTask" do
     needs_configuration
 
     # The analog input when the position is the minimun
-    property "input_min", "/float", -1
+    property "analog_min", "/float", -1
     # The analog input when the position is the maximum
-    property "input_max", "/float", 1
+    property "analog_max", "/float", 1
     # The minimum position
     property "position_min", "/float", -1
     # The maximum position
     property "position_max", "/float", 1
 
     # The analog readings
-    output_port "analog_input", "/std/vector</raw_io/Analog>"
+    output_port "analog_out", "/std/vector</raw_io/Analog>"
     # The position samples
     input_port "position_samples", "/base/samples/Joints"
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,5 +11,6 @@
   <depend package="control/uuv_tether_control"/>
   <depend package="control/orogen/control_base"/>
   <depend package="drivers/orogen/linux_gpios"/>
+  <depend package="drivers/orogen/raw_io" />
   <test_depend name="tools/syskit" />
 </package>

--- a/tasks/RudderActuatorPositionToAnalogTask.cpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.cpp
@@ -40,13 +40,13 @@ void RudderActuatorPositionToAnalogTask::updateHook()
         return;
     }
 
-    if (m_position.elements.empty() || !m_position.elements[0].hasPosition()) {
+    if (m_position.elements.size() != 1 || !m_position.elements[0].hasPosition()) {
         return exception(INVALID_POSITION_SAMPLE);
     }
 
-    float position = m_position.elements[0].position;
+    double position = m_position.elements[0].position;
 
-    float analog_value =
+    double analog_value =
         m_analog_min + (position - m_position_min) * m_analog_per_length_ratio;
 
     m_analog_out[0].time = m_position.time;

--- a/tasks/RudderActuatorPositionToAnalogTask.cpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.cpp
@@ -19,11 +19,11 @@ bool RudderActuatorPositionToAnalogTask::configureHook()
     if (!RudderActuatorPositionToAnalogTaskBase::configureHook())
         return false;
 
-    m_input_min = _input_min.get();
-    m_input_max = _input_max.get();
+    m_analog_min = _analog_min.get();
     m_position_min = _position_min.get();
-    m_position_max = _position_max.get();
-    m_analog_input.resize(1);
+    m_analog_per_length_ratio =
+        (_analog_max.get() - m_analog_min) / (_position_max.get() - m_position_min);
+    m_analog_out.resize(1);
 
     return true;
 }
@@ -36,22 +36,23 @@ bool RudderActuatorPositionToAnalogTask::startHook()
 void RudderActuatorPositionToAnalogTask::updateHook()
 {
     RudderActuatorPositionToAnalogTaskBase::updateHook();
-    while (_position_samples.read(m_position) == RTT::NewData) {
-        if (m_position.elements.empty() || !m_position.elements[0].hasPosition()) {
-            return exception(INVALID_POSITION_SAMPLE);
-        }
-
-        float position = m_position.elements[0].position;
-
-        float analog_value = m_input_min + (position - m_position_min) *
-                                               (m_input_max - m_input_min) /
-                                               (m_position_max - m_position_min);
-
-        m_analog_input[0].time = m_position.time;
-        m_analog_input[0].data = analog_value;
-
-        _analog_input.write(m_analog_input);
+    if (_position_samples.read(m_position) != RTT::NewData) {
+        return;
     }
+
+    if (m_position.elements.empty() || !m_position.elements[0].hasPosition()) {
+        return exception(INVALID_POSITION_SAMPLE);
+    }
+
+    float position = m_position.elements[0].position;
+
+    float analog_value =
+        m_analog_min + (position - m_position_min) * m_analog_per_length_ratio;
+
+    m_analog_out[0].time = m_position.time;
+    m_analog_out[0].data = analog_value;
+
+    _analog_out.write(m_analog_out);
 }
 void RudderActuatorPositionToAnalogTask::errorHook()
 {

--- a/tasks/RudderActuatorPositionToAnalogTask.cpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.cpp
@@ -1,0 +1,67 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "RudderActuatorPositionToAnalogTask.hpp"
+
+using namespace gazebo_usv;
+
+RudderActuatorPositionToAnalogTask::RudderActuatorPositionToAnalogTask(
+    std::string const& name)
+    : RudderActuatorPositionToAnalogTaskBase(name)
+{
+}
+
+RudderActuatorPositionToAnalogTask::~RudderActuatorPositionToAnalogTask()
+{
+}
+
+bool RudderActuatorPositionToAnalogTask::configureHook()
+{
+    if (!RudderActuatorPositionToAnalogTaskBase::configureHook())
+        return false;
+
+    m_input_min = _input_min.get();
+    m_input_max = _input_max.get();
+    m_position_min = _position_min.get();
+    m_position_max = _position_max.get();
+    m_analog_input.resize(1);
+
+    return true;
+}
+bool RudderActuatorPositionToAnalogTask::startHook()
+{
+    if (!RudderActuatorPositionToAnalogTaskBase::startHook())
+        return false;
+    return true;
+}
+void RudderActuatorPositionToAnalogTask::updateHook()
+{
+    RudderActuatorPositionToAnalogTaskBase::updateHook();
+    while (_position_samples.read(m_position) == RTT::NewData) {
+        if (m_position.elements.empty() || !m_position.elements[0].hasPosition()) {
+            return exception(INVALID_POSITION_SAMPLE);
+        }
+
+        float position = m_position.elements[0].position;
+
+        float analog_value = m_input_min + (position - m_position_min) *
+                                               (m_input_max - m_input_min) /
+                                               (m_position_max - m_position_min);
+
+        m_analog_input[0].time = m_position.time;
+        m_analog_input[0].data = analog_value;
+
+        _analog_input.write(m_analog_input);
+    }
+}
+void RudderActuatorPositionToAnalogTask::errorHook()
+{
+    RudderActuatorPositionToAnalogTaskBase::errorHook();
+}
+void RudderActuatorPositionToAnalogTask::stopHook()
+{
+    RudderActuatorPositionToAnalogTaskBase::stopHook();
+}
+void RudderActuatorPositionToAnalogTask::cleanupHook()
+{
+    RudderActuatorPositionToAnalogTaskBase::cleanupHook();
+}

--- a/tasks/RudderActuatorPositionToAnalogTask.hpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.hpp
@@ -11,13 +11,12 @@ namespace gazebo_usv {
         friend class RudderActuatorPositionToAnalogTaskBase;
 
     protected:
-        float m_input_min;
-        float m_input_max;
+        float m_analog_min;
         float m_position_min;
-        float m_position_max;
+        float m_analog_per_length_ratio;
 
         base::samples::Joints m_position;
-        std::vector<raw_io::Analog> m_analog_input;
+        std::vector<raw_io::Analog> m_analog_out;
 
     public:
         RudderActuatorPositionToAnalogTask(

--- a/tasks/RudderActuatorPositionToAnalogTask.hpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.hpp
@@ -1,0 +1,35 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef GAZEBO_USV_RUDDERACTUATORPOSITIONTOANALOGTASK_TASK_HPP
+#define GAZEBO_USV_RUDDERACTUATORPOSITIONTOANALOGTASK_TASK_HPP
+
+#include "gazebo_usv/RudderActuatorPositionToAnalogTaskBase.hpp"
+
+namespace gazebo_usv {
+    class RudderActuatorPositionToAnalogTask
+        : public RudderActuatorPositionToAnalogTaskBase {
+        friend class RudderActuatorPositionToAnalogTaskBase;
+
+    protected:
+        float m_input_min;
+        float m_input_max;
+        float m_position_min;
+        float m_position_max;
+
+        base::samples::Joints m_position;
+        std::vector<raw_io::Analog> m_analog_input;
+
+    public:
+        RudderActuatorPositionToAnalogTask(
+            std::string const& name = "gazebo_usv::RudderActuatorPositionToAnalogTask");
+        ~RudderActuatorPositionToAnalogTask();
+        bool configureHook();
+        bool startHook();
+        void updateHook();
+        void errorHook();
+        void stopHook();
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/tasks/RudderActuatorPositionToAnalogTask.hpp
+++ b/tasks/RudderActuatorPositionToAnalogTask.hpp
@@ -11,9 +11,9 @@ namespace gazebo_usv {
         friend class RudderActuatorPositionToAnalogTaskBase;
 
     protected:
-        float m_analog_min;
-        float m_position_min;
-        float m_analog_per_length_ratio;
+        double m_analog_min;
+        double m_position_min;
+        double m_analog_per_length_ratio;
 
         base::samples::Joints m_position;
         std::vector<raw_io::Analog> m_analog_out;

--- a/test/rudder_actuator_position_to_analog_task_test.rb
+++ b/test/rudder_actuator_position_to_analog_task_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+using_task_library "gazebo_usv"
+
+describe OroGen.gazebo_usv.RudderActuatorPositionToAnalogTask do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen.gazebo_usv.RudderActuatorPositionToAnalogTask
+                  .deployed_as("task_under_test")
+        )
+    end
+
+    it "mirrors the position on the analog output with the default configuration" do
+        syskit_configure_and_start(@task)
+
+        position = make_joints(position: 0.1)
+        analog = expect_execution { syskit_write @task.position_samples_port, position }
+                   .to { have_one_new_sample task.analog_input_port }
+
+        assert_equal position.time, analog[0].time
+        assert_in_delta 0.1, analog[0].data
+    end
+
+    it "converts the position using the provided min/max values" do
+        @task.properties.input_min = 200
+        @task.properties.input_max = 400
+        @task.properties.position_min = -1
+        @task.properties.position_max = 1
+
+        syskit_configure_and_start(@task)
+
+        position = make_joints(position: -0.5)
+        analog =
+            expect_execution do
+                syskit_write @task.position_samples_port, position
+            end.to { have_one_new_sample task.analog_input_port }
+
+        assert_in_delta 250.0, analog[0].data
+    end
+
+    it "emits INVALID_POSITION_SAMPLE if input sample mode is not POSITION" do
+        syskit_configure_and_start(@task)
+
+        sample = make_joints(speed: -0.5)
+        expect_execution do
+            syskit_write @task.position_samples_port, sample
+        end.to do
+            emit task.invalid_position_sample_event
+        end
+    end
+
+    def make_joints(fields, now: Time.now)
+        joint_state = Types.base.JointState.new(
+            fields
+        )
+
+        joints = Types.base.samples.Joints.new(
+            time: now,
+            elements: [joint_state]
+        )
+        joints
+    end
+end

--- a/test/rudder_actuator_position_to_analog_task_test.rb
+++ b/test/rudder_actuator_position_to_analog_task_test.rb
@@ -19,15 +19,15 @@ describe OroGen.gazebo_usv.RudderActuatorPositionToAnalogTask do
 
         position = make_joints(position: 0.1)
         analog = expect_execution { syskit_write @task.position_samples_port, position }
-                   .to { have_one_new_sample task.analog_input_port }
+                   .to { have_one_new_sample task.analog_out_port }
 
         assert_equal position.time, analog[0].time
         assert_in_delta 0.1, analog[0].data
     end
 
     it "converts the position using the provided min/max values" do
-        @task.properties.input_min = 200
-        @task.properties.input_max = 400
+        @task.properties.analog_min = 200
+        @task.properties.analog_max = 400
         @task.properties.position_min = -1
         @task.properties.position_max = 1
 
@@ -37,7 +37,7 @@ describe OroGen.gazebo_usv.RudderActuatorPositionToAnalogTask do
         analog =
             expect_execution do
                 syskit_write @task.position_samples_port, position
-            end.to { have_one_new_sample task.analog_input_port }
+            end.to { have_one_new_sample task.analog_out_port }
 
         assert_in_delta 250.0, analog[0].data
     end

--- a/test/rudder_actuator_position_to_analog_task_test.rb
+++ b/test/rudder_actuator_position_to_analog_task_test.rb
@@ -53,14 +53,25 @@ describe OroGen.gazebo_usv.RudderActuatorPositionToAnalogTask do
         end
     end
 
-    def make_joints(fields, now: Time.now)
+    it "emits INVALID_POSITION_SAMPLE if input sample elements size is not 1" do
+        syskit_configure_and_start(@task)
+
+        sample = make_joints(speed: -0.5, size: 2)
+        expect_execution do
+            syskit_write @task.position_samples_port, sample
+        end.to do
+            emit task.invalid_position_sample_event
+        end
+    end
+
+    def make_joints(now: Time.now, size: 1, **fields)
         joint_state = Types.base.JointState.new(
             fields
         )
 
         joints = Types.base.samples.Joints.new(
             time: now,
-            elements: [joint_state]
+            elements: [joint_state] * size
         )
         joints
     end


### PR DESCRIPTION
# What is this PR for
feat: add task to convert rudder linear position into analog feedback
this is useful to simulate the ruddder linear actuator from gazebo joint

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)